### PR TITLE
ci: implemented mechanism to share common config

### DIFF
--- a/.github/files-sync-config.yaml
+++ b/.github/files-sync-config.yaml
@@ -1,0 +1,14 @@
+# Configuration file used by the product-file-sync.yml workflow
+settings:
+  pull_request:
+    disabled: true
+  commit: 
+    format: '<%- prefix %>: <%- subject %>'
+    prefix: 'chore'
+    subject: 'sync files with `<%- repository %> [skip ci]`  
+patterns:
+  - files:
+      - .github/release.yml
+      - .github/workflows/delivery-issue-chores.yml
+    repositories:
+      - Jahia/sandbox@main

--- a/.github/workflows/delivery-issue-chores.yml
+++ b/.github/workflows/delivery-issue-chores.yml
@@ -1,0 +1,10 @@
+name: Delivery - Issue Chores
+
+on:
+  issues:
+  issue_comment:
+
+jobs:
+  WF:
+    uses: Jahia/jahia-modules-action/.github/workflows/issue-chores.yml@v2
+    secrets: inherit

--- a/.github/workflows/product-file-sync.yml
+++ b/.github/workflows/product-file-sync.yml
@@ -1,0 +1,18 @@
+# Synchronize common workflows and configuration across all product repositories
+name: Product - Sync. Files
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  file_sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wadackel/files-sync-action@v3
+        with:
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}        

--- a/.github/workflows/product-file-sync.yml
+++ b/.github/workflows/product-file-sync.yml
@@ -2,9 +2,7 @@
 name: Product - Sync. Files
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
   schedule:
     - cron: 0 0 * * *
 


### PR DESCRIPTION
This defines a workflow and a configuration to share specific files across all repos of the organization.

I couldn't think of a good way to do that automatically for all product repositories and believe it should be actually configured manually/individually (i.e. from one single central place such as the .github repository).

It is technically feasible (get the list of repos with the "product" topic, automatically push to these), but I do see the potential for issues. Instead, the idea is to add new repos to that list (we might want to update the confluence page detailing repo configuration).