### PR TITLE
ci: Implemented repo chores

### DIFF
--- a/.github/files-sync-config.yaml
+++ b/.github/files-sync-config.yaml
@@ -17,5 +17,6 @@ patterns:
       - .github/release.yml
       - .github/workflows/delivery-issue-chores.yml
       - .github/workflows/delivery-pr-chores.yml
+      - .github/workflows/delivery-repo-chores.yml
     repositories:
       - Jahia/sandbox@main

--- a/.github/workflows/delivery-issue-chores.yml
+++ b/.github/workflows/delivery-issue-chores.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   WF:
-    uses: Jahia/jahia-modules-action/.github/workflows/issue-chores.yml@v2
+    uses: Jahia/jahia-modules-action/.github/workflows/delivery-issue-chores.yml@v2
     secrets: inherit

--- a/.github/workflows/delivery-pr-chores.yml
+++ b/.github/workflows/delivery-pr-chores.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   WF:
-    uses: Jahia/jahia-modules-action/.github/workflows/pr-chores.yml@v2
+    uses: Jahia/jahia-modules-action/.github/workflows/delivery-pr-chores.yml@v2
     secrets: inherit

--- a/.github/workflows/delivery-repo-chores.yml
+++ b/.github/workflows/delivery-repo-chores.yml
@@ -1,0 +1,11 @@
+name: Delivery - PR Chores
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 0" # 2 AM every Sunday
+
+jobs:
+  WF:
+    uses: Jahia/jahia-modules-action/.github/workflows/delivery-repo-chores.yml@v2
+    secrets: inherit


### PR DESCRIPTION
 - The goal is to prevent github actions from being disabled on inactive repos. Note that there does not seem to be a way to avoid starting the job altogether based on some conditions, so it will trigger 180 jobs (each should take a minimum amount of time though). There might be a better solution on the long run, but for now I couldn't find a better alternative
 - Also used this opportunity to rename workflows; this goes alongside this PR: https://github.com/Jahia/jahia-modules-action/pull/175
