### PR TITLE
feat: Added a workflow to list product repositories

### DIFF
--- a/.github/delivery-list-repos-cfg.js
+++ b/.github/delivery-list-repos-cfg.js
@@ -1,0 +1,12 @@
+// This file contains the json2csv transformation config to create a CSV
+// See: https://juanjodiaz.github.io/json2csv/#/parsers/cli
+export default {
+    fields: [
+      {
+        label: '',
+        value: row => {
+          return row.nameWithOwner + '@' + row.defaultBranchRef.name
+        }
+      }
+    ]
+  }

--- a/.github/workflows/delivery-list-repos.yml
+++ b/.github/workflows/delivery-list-repos.yml
@@ -1,0 +1,36 @@
+# This workflow lists all repositories matching specific topics.
+# It is useful to obtain the list of repositories that needs to be updated by the file-sync workflow
+# and then copy/paste this list in the configuration
+name: Delivery - List repositories
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-repos-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Get Org Repositories
+        id: get-repos
+        uses: fgerthoffert/actions-get-org-repos@v1.0.0
+        with:
+          org: jahia
+          token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          filter_topics: product,community
+          filter_operator: OR
+          filter_ignore_archived: true
+
+      - name: Convert the NDJSON to CSV
+        shell: bash
+        run: |
+          npx @json2csv/cli -i ${{ steps.get-repos.outputs.artifact_filepath }} --ndjson --config ${{ github.workspace }}/.github/delivery-list-repos-cfg.js -o repositories.csv
+
+      - name: List repositories
+        shell: bash
+        run: |
+          cat repositories.csv | tr -d \"
+


### PR DESCRIPTION
The [product-file-sync.yml](https://github.com/Jahia/.github/blob/list-repos/.github/workflows/product-file-sync.yml) workflow relies on a configuration containing a list of repositories to update.

Since this list is very large, this new workflow allows us to get a list we can copy and paste into the file.