### PR TITLE
fix: restrict labels sync to product repos

### DIFF
--- a/.github/workflows/delivery-sync-labels.yml
+++ b/.github/workflows/delivery-sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
           org: jahia
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
           src_repository: .github
-          filter_topics: product,cloud,community
+          filter_topics: product
           filter_operator: OR
 


### PR DESCRIPTION
There were a bunch of errors in the workflows while trying to modify repositories for which jahia-ci does not have write permissions.
