### PR TITLE
fix: added the missing edited event to the PR workflow

### DIFF
--- a/.github/workflows/delivery-pr-chores.yml
+++ b/.github/workflows/delivery-pr-chores.yml
@@ -4,6 +4,11 @@ name: Delivery - PR Chores
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize  
   pull_request_review:
 
 jobs:


### PR DESCRIPTION
This must have been removed alongside the various tests we were doing, but looking at the [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request):


> By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. To trigger workflows by different activity types, use the types keyword. 


This adds the "edited" type, which is triggered when editing the title of a PR.