### PR TITLE
feat: exlude jahia-ci PRs from appearing in the release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,8 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+    authors:
+      - jahia-ci
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

On the short-term, this will prevent the file sync PRs from appearing, on the long-run there are no reasons for changes done by jahia-ci to appear in the release notes.