### PR TITLE
feat: update tech-day template after workshop

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -45,6 +45,11 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🙏 Remove unused libraries
 ### Jahia Modules
 - [ ] 🚨 If the codebase is a module shipped with the distribution, the latest version with changes is configured in jahia-pack ([core](https://github.com/Jahia/jahia-pack-private/blob/master/core-modules/pom.xml) or [additional-modules](https://github.com/Jahia/jahia-pack-private/blob/master/additional-modules/pom.xml))
+### Codebase management
+- [ ] 🟠 I reviewed opportunities to remove dead/unused/unreachable code
+- [ ] 🙏 I reviewed opportunities to merge codebases within the repository
+- [ ] 🟠 No code smell on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
+- [ ] 🔝 No warnings or errors are present when building the module locally or on GitHub Actions
 ### Javascript
 - [ ] 🔝 The module's webpack config is correct ([sample](https://github.com/Jahia/jcontent/blob/master/webpack.config.js))
 - [ ] 🔝 The module is using a supported LTS version of ([NodeJS](https://nodejs.org/en/about/previous-releases))
@@ -61,9 +66,6 @@ This checklist is there to help you but is not exaustive, if some items are not 
 ### Java
 - [ ] 🔝 Java dependencies are explicitly declared in the module's pom.xml
 - [ ] 🔝 Spring is not used in the module
-- [ ] 🔝 No warnings or errors are present when building the module locally or on GitHub Actions
-- [ ] 🟠 No code smell on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
-- [ ] 🙏 Remove unreachable code
 ### Security
 - [ ] 🔝 Review the [security vulnerabilities](https://dependency-track-prod.jahia.com/) affecting this codebase and discuss with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
 ### QA / Automated Tests

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -91,7 +91,7 @@ This checklist is there to help you but is not exaustive, if some items are not 
 ### Issues
 - [ ] 🟠 If the repository is public, issues/pull requests from the community have been reviewed and answered, if answer was not possible, a PM/DM was notified.
 ### GitHub
-- [ ] 🟠 [Branch protection](https://confluence.jahia.com/display/PR/GitHub+%28Product%29+-+Ref+ISPOL08.A14025#GitHub(Product)RefISPOL08.A14025-Branchprotection) is enabled for the repository
+- [ ] 🟠 [Branch protection](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2067858/GitHub+Product+-+Ref+ISPOL08.A14025#Branch-protection) is enabled for the repository
 - [ ] **Automatically delete head branches** is selected in **Settings**
 - [ ] 🙏 Repository topics match are populated (at a minimum: "product" and "supported")
 - [ ] 🙏 Stale branches or branches older than 2 years (non-maintenance branches) have been removed
@@ -104,12 +104,12 @@ This checklist is focused on our forked repositories
 - [ ] 🚨 I checked that we cannot stop using a fork of the library
 - [ ] 🚨 I created pull requests to push the fixes done in our fork to the main repository
 - [ ] 🚨 I checked that we cannot upgrade to a more recent
-- [ ] 🚨 I checked that we've documented why we're still using a fork of this library in [confluence](https://confluence.jahia.com/display/PR/Releasing+our+project+forks)
+- [ ] 🚨 I checked that we've documented why we're still using a fork of this library in [confluence](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2065402/Releasing+our+project+forks)
 ### Security
 - [ ] 🔝 I checked that there are no known security vulnerabilities affecting this codebase
 ### CI/CD
-- [ ] 🚨 The build and the release/publish workflows are configured (or at least documented in [confluence](https://confluence.jahia.com/display/PR/Releasing+our+project+forks))
+- [ ] 🚨 The build and the release/publish workflows are configured (or at least documented in [confluence](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2065402/Releasing+our+project+forks))
 ### GitHub
-- [ ] 🟠 [Branch protection](https://confluence.jahia.com/display/PR/GitHub+%28Product%29+-+Ref+ISPOL08.A14025#GitHub(Product)RefISPOL08.A14025-Branchprotection) is enabled for the repository
+- [ ] 🟠 [Branch protection](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2067858/GitHub+Product+-+Ref+ISPOL08.A14025#Branch-protection) is enabled for the repository
 - [ ] **Automatically delete head branches** is selected in **Settings**
 - [ ] 🙏 Repository topics match are populated (at a minimum: "product" and "supported")

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -34,7 +34,7 @@ When creating such tickets, try to provide details about complexity of such an i
 
 ## Checklist
 
-This checklist is there to help you but is not exaustive, if some items are not relevant or should be added, please submit a ticket.
+This checklist is there to help you but is not exaustive, if some items are not relevant or should be added, [please request a change](https://github.com/Jahia/.github/blob/master/.github/ISSUE_TEMPLATE/custom_product/tech-day.md).
 
 ### General
 - [ ] 🚨 I reviewed all OPEN TECH tickets created for that codebase (using codebase-X.Y.Z milestone)

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -46,10 +46,10 @@ This checklist is there to help you but is not exaustive, if some items are not 
 ### Jahia Modules
 - [ ] 🚨 If the codebase is a module shipped with the distribution, the latest version with changes is configured in jahia-pack ([core](https://github.com/Jahia/jahia-pack-private/blob/master/core-modules/pom.xml) or [additional-modules](https://github.com/Jahia/jahia-pack-private/blob/master/additional-modules/pom.xml))
 ### Codebase management
-- [ ] 🟠 I reviewed opportunities to remove dead/unused/unreachable code
-- [ ] 🙏 I reviewed opportunities to merge codebases within the repository
-- [ ] 🟠 No code smell on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
 - [ ] 🔝 No warnings or errors are present when building the module locally or on GitHub Actions
+- [ ] 🟠 I reviewed opportunities to remove dead/unused/unreachable code
+- [ ] 🟠 No code smell on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
+- [ ] 🙏 I reviewed opportunities to merge codebases within the repository
 ### Javascript
 - [ ] 🔝 The module's webpack config is correct ([sample](https://github.com/Jahia/jcontent/blob/master/webpack.config.js))
 - [ ] 🔝 The module is using a supported LTS version of ([NodeJS](https://nodejs.org/en/about/previous-releases))

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -47,6 +47,7 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🙏 Remove unused libraries
 ### Jahia Modules
 - [ ] 🚨 If the codebase is a module shipped with the distribution, the latest version with changes is configured in jahia-pack ([core](https://github.com/Jahia/jahia-pack-private/blob/master/core-modules/pom.xml) or [additional-modules](https://github.com/Jahia/jahia-pack-private/blob/master/additional-modules/pom.xml))
+- [ ] 🟠 Make sure dependencies (and appropriate version if needed) are declared in **jahia-depends**
 ### Codebase management
 - [ ] 🔝 No warnings or errors are present when building the module locally or on GitHub Actions
 - [ ] 🟠 I reviewed opportunities to remove dead/unused/unreachable code

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -27,10 +27,10 @@ When creating such tickets, try to provide details about complexity of such an i
 
 ## About priorities
 
-🚨 Indicates a required item, to be looked at
-🔝 Indicates a top priority item
-🟠 Indicates a medium priority item
-🙏 Indicates a low priority item
+* 🚨 Indicates a required item, to be looked at
+* 🔝 Indicates a top priority item
+* 🟠 Indicates a medium priority item
+* 🙏 Indicates a low priority item
 
 ## Checklist
 

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -40,6 +40,7 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🚨 I reviewed all OPEN TECH tickets created for that codebase (using codebase-X.Y.Z milestone)
 - [ ] 🚨 I reviewed older tech day tickets for that codebase
 - [ ] 🟠 Standards have been discussed in a tech kumite in the past semester
+- [ ] 🙏 Module's license is up-to-date (see https://github.com/Jahia/open-source/blob/master/README.md#licenses)
 ### Dependency management
 - [ ] 🔝 I've identified the process/tools to handle dependency updates (ex: [renovate](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2071358/3rd-party+libraries+-+Ref+ISPOL08.A14024#%5BinlineExtension%5DRenovate))
 - [ ] 🟠 Ensure licenses used by the libraries are [Jahia compliant](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2068350/License+check+-+Ref+ISSOP08.A14020)

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -42,6 +42,7 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🟠 Standards have been discussed in a tech kumite in the past semester
 ### Dependency management
 - [ ] 🔝 I've identified the process/tools to handle dependency updates (ex: [renovate](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2071358/3rd-party+libraries+-+Ref+ISPOL08.A14024#%5BinlineExtension%5DRenovate))
+- [ ] 🟠 Ensure licenses used by the libraries are [Jahia compliant](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2068350/License+check+-+Ref+ISSOP08.A14020)
 - [ ] 🙏 Remove unused libraries
 ### Jahia Modules
 - [ ] 🚨 If the codebase is a module shipped with the distribution, the latest version with changes is configured in jahia-pack ([core](https://github.com/Jahia/jahia-pack-private/blob/master/core-modules/pom.xml) or [additional-modules](https://github.com/Jahia/jahia-pack-private/blob/master/additional-modules/pom.xml))

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -7,32 +7,34 @@ labels: ['Tech Day', 'Area:Tech']
 
 ---
 
-The goal of this ticket is to work on technical debt for a repository within a fixed time window of 1 day.
+The goal of this issue is to work on technical debt for a repository as part of the codebase ownership initiative. It is organized around team members regularly reviewing the state of codebases.
 
-## Organizing of your day
+Creating a tech day ticket is not required to work on tech debt, but can be a helpful resource to identify areas of focus.
 
-One day will NOT be sufficient to address technical debt for the codebase, organizing your day is key to wrap-up the tasks with concrete deliverable.
+## Recommendations
 
-We recommend following this schedule:
-- Begin by spending 1 hour to go over the checklist attached to this ticket, identify activities you would be able to complete within the day and create tickets for activities that would require more work or that you don't expect to complete. Make sure to link these new ticket to the techday ticket and to attach it to the checklist.
-- Work on items identified during the first hour.
-- Wrap up your day by spending 1 hour to document the changes you did, provide instructions for testing and eventually to give pointers to the next person working on a techday ticket for this codebase.
+You will not be able to address the entierety of a codebase tech debt in one go, organization is key to make sure you wrap-up time spent on a codebase with concrete deliverables.
+
+When dedicating a fixed amount of time on a codebase, we recommend the following schedule:
+- Begin by reviewing the checklist attached to this ticket, identify and prioritize activities you would be able to complete within the dedicated time.
+- Work on said items.
+- Wrap up by briefly documenting the changes you did, provide instructions for testing and eventually create issues for activities you'd like to work on next. You can do so by adding a comment to this issue.
 
 ## Create tickets for future work
-Not all tech debt items can be addressed within a day, the goal of this day is also to raise awareness about tech debt to be tackled in the future.
+Not all tech debt items can be addressed in one day, one of the goal of the ownership initiative is also to raise awareness about tech debt to be tackled in the future.
 
-If you see a non-compliant element but you didn't get a chance to work on it, please create the corresponding ticket, attach it to the next fixVersion of the codebase and link it in this ticket.
+When creating such tickets, try to provide details about complexity of such an implementation. These elements play a role in our capacity to prioritize work.
 
-Please fill the checklist available in this ticket, priorities are available as a guideline as to what we consider more or less important for each of the tech areas:
+## About priorities
 
-🚨 Indicates a required item, to be looked at during the day
+🚨 Indicates a required item, to be looked at
 🔝 Indicates a top priority item
 🟠 Indicates a medium priority item
 🙏 Indicates a low priority item
 
-## Tech day checklist
+## Checklist
 
-This checklist is focused on a classic Jahia repository (module, app)
+This checklist is there to help you but is not exaustive, if some items are not relevant or should be added, please submit a ticket.
 
 ### General
 - [ ] 🚨 I reviewed all OPEN TECH tickets created for that codebase (using codebase-X.Y.Z milestone)
@@ -41,6 +43,8 @@ This checklist is focused on a classic Jahia repository (module, app)
 ### Dependency management
 - [ ] 🔝 I've identified the process/tools to handle dependency updates (ex: [renovate](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2071358/3rd-party+libraries+-+Ref+ISPOL08.A14024#%5BinlineExtension%5DRenovate))
 - [ ] 🙏 Remove unused libraries
+### Jahia Modules
+- [ ] 🚨 If the codebase is a module shipped with the distribution, the latest version with changes is configured in jahia-pack ([core](https://github.com/Jahia/jahia-pack-private/blob/master/core-modules/pom.xml) or [additional-modules](https://github.com/Jahia/jahia-pack-private/blob/master/additional-modules/pom.xml))
 ### Javascript
 - [ ] 🔝 The module's webpack config is correct ([sample](https://github.com/Jahia/jcontent/blob/master/webpack.config.js))
 - [ ] 🔝 The module is using a supported LTS version of ([NodeJS](https://nodejs.org/en/about/previous-releases))
@@ -61,32 +65,34 @@ This checklist is focused on a classic Jahia repository (module, app)
 - [ ] 🟠 No code smell on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
 - [ ] 🙏 Remove unreachable code
 ### Security
-- [ ] 🔝 Review the [security vulnerabilities](ndency-track-prod.jahia.com/projects) affecting this codebase and discuss with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
-### QA
+- [ ] 🔝 Review the [security vulnerabilities](https://dependency-track-prod.jahia.com/) affecting this codebase and discuss with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
+### QA / Automated Tests
+- [ ] 🚨 The codebase is compatible with the latest release of Jahia
 - [ ] 🔝 Automated tests are using jahia-cypress for all utils functions
 - [ ] 🔝 The test framework is using page-object models published by other modules
 - [ ] 🔝 The test framework is publishing its own page-object models for use by others
 - [ ] 🟠 A manual-run workflow is available
+- [ ] 🟠 Instructions and [test cases](https://jahia.testrail.net/index.php?/dashboard) are available to document how a release should be tested
 - [ ] 🙏 Automated tests are using a recent version of Cypress
 - [ ] 🙏 Automated tests are only relying on supported modules
 ### CI/CD
 - [ ] 🔝 The build and the release workflows use the JDK 11 image (only if Jahia Parent is set to 8.2.0.0+)
-- [ ] 🔝 GitHub Actions (nightlys and other workflows) are executed without warnings (such as depreciations)
+- [ ] 🔝 GitHub Actions (nightlys and other workflows) are executed without warnings nor errors (such as depreciations, failed tests, ...)
 - [ ] 🙏 The latest version of the actions are used (including jahia-modules-action)
-- [ ] 🙏 The [reusable workflows](https://github.com/Jahia/jahia-modules-action/tree/main/.github/workflows) are used
+- [ ] 🙏 GitHub Actions [reusable workflows](https://github.com/Jahia/jahia-modules-action/tree/main/.github/workflows) are used
 ### Documentation
 - [ ] 🔝 Readme.md is up-to-date (module purpose, technical details, configuration steps)
 - [ ] 🟠 A tech roadmap is available 
 - [ ] 🙏 Module's documentation available on the academy is up-to-date
 ### Issues
-- [ ] 🟠 If the repository is public, review the issues/pull requests from the community and give feedback
+- [ ] 🟠 If the repository is public, issues/pull requests from the community have been reviewed and answered, if answer was not possible, a PM/DM was notified.
 ### GitHub
 - [ ] 🟠 [Branch protection](https://confluence.jahia.com/display/PR/GitHub+%28Product%29+-+Ref+ISPOL08.A14025#GitHub(Product)RefISPOL08.A14025-Branchprotection) is enabled for the repository
 - [ ] **Automatically delete head branches** is selected in **Settings**
 - [ ] 🙏 Repository topics match are populated (at a minimum: "product" and "supported")
 - [ ] 🙏 Stale branches or branches older than 2 years (non-maintenance branches) have been removed
 
-## Fork day checklist
+## Fork checklist
 
 This checklist is focused on our forked repositories
 

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -51,7 +51,7 @@ This checklist is there to help you but is not exaustive, if some items are not 
 ### Codebase management
 - [ ] 🔝 No warnings or errors are present when building the module locally or on GitHub Actions
 - [ ] 🟠 I reviewed opportunities to remove dead/unused/unreachable code
-- [ ] 🟠 No code smell on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
+- [ ] 🟠 No blocker issues on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
 - [ ] 🙏 I reviewed opportunities to merge codebases within the repository
 ### Javascript
 - [ ] 🔝 The module's webpack config is correct ([sample](https://github.com/Jahia/jcontent/blob/master/webpack.config.js))
@@ -70,7 +70,9 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🔝 Java dependencies are explicitly declared in the module's pom.xml
 - [ ] 🔝 Spring is not used in the module
 ### Security
-- [ ] 🔝 Review the [security vulnerabilities](https://dependency-track-prod.jahia.com/) affecting this codebase and discuss with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
+- [ ] 🚨 SBOM is generated (configuration available [here](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2071358/3rd-party+libraries+-+Ref+ISPOL08.A14024#%5BinlineExtension%5DSBOM-creation-and-OWASP-Dependency-Track)) and uploaded to [Dependency Track](https://dependency-track-prod.jahia.com/)
+- [ ] 🔝 Review the security [vulnerabilities](https://sonarqube.jahia.com/issues?resolved=false&types=VULNERABILITY) and [hotspots](https://sonarqube.jahia.com/security_hotspots?id=org.jahia.server%3Ajahia-root) affecting this codebase and discuss with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
+- [ ] 🔝 A job running Sonar checks (including OWASP Dependency Check) is executed regularly
 ### QA / Automated Tests
 - [ ] 🚨 The codebase is compatible with the latest release of Jahia
 - [ ] 🔝 Automated tests are using jahia-cypress for all utils functions
@@ -92,7 +94,7 @@ This checklist is there to help you but is not exaustive, if some items are not 
 ### Issues
 - [ ] 🟠 If the repository is public, issues/pull requests from the community have been reviewed and answered, if answer was not possible, a PM/DM was notified.
 ### GitHub
-- [ ] 🟠 [Branch protection](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2067858/GitHub+Product+-+Ref+ISPOL08.A14025#Branch-protection) is enabled for the repository
+- [ ] 🚨 [Branch protection](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2067858/GitHub+Product+-+Ref+ISPOL08.A14025#Branch-protection) is enabled for the repository
 - [ ] **Automatically delete head branches** is selected in **Settings**
 - [ ] 🙏 Repository topics match are populated (at a minimum: "product" and "supported")
 - [ ] 🙏 Stale branches or branches older than 2 years (non-maintenance branches) have been removed

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -65,7 +65,6 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🟠 Dependencies listed in packages.json are no more than 2 major versions behind their latest release
 - [ ] 🟠 Linting is executed properly and show no warnings
 - [ ] 🟠 No warning are presents in the browser console when using the app
-- [ ] 🙏 Remove unreachable code
 ### Java
 - [ ] 🔝 Java dependencies are explicitly declared in the module's pom.xml
 - [ ] 🔝 Spring is not used in the module
@@ -79,12 +78,12 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🔝 Automated tests are using jahia-cypress for all utils functions
 - [ ] 🔝 The test framework is using page-object models published by other modules
 - [ ] 🔝 The test framework is publishing its own page-object models for use by others
-- [ ] 🟠 A manual-run workflow is available
+- [ ] 🟠 A manual-run workflow is available (ex: [manual-run.yml](https://github.com/Jahia/jcontent/blob/master/.github/workflows/manual-run.yml))
 - [ ] 🟠 Instructions and [test cases](https://jahia.testrail.net/index.php?/dashboard) are available to document how a release should be tested (how to do the "sanity check" of this module)
 - [ ] 🙏 Automated tests are using a recent version of Cypress
 - [ ] 🙏 Automated tests are only relying on supported modules
 ### CI/CD
-- [ ] 🔝 The build and the release workflows use the JDK 11 image (only if Jahia Parent is set to 8.2.0.0+)
+- [ ] 🔝 The build and the release workflows use the JDK 11 image (only if Jahia Parent is set to 8.2.0.0+) from temurin vendor
 - [ ] 🔝 GitHub Actions (nightlys and other workflows) are executed without warnings nor errors (such as depreciations, failed tests, ...)
 - [ ] 🙏 The latest version of the actions are used (including jahia-modules-action)
 - [ ] 🙏 GitHub Actions [reusable workflows](https://github.com/Jahia/jahia-modules-action/tree/main/.github/workflows) are used

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -71,7 +71,8 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🔝 Spring is not used in the module
 ### Security
 - [ ] 🚨 SBOM is generated (configuration available [here](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2071358/3rd-party+libraries+-+Ref+ISPOL08.A14024#%5BinlineExtension%5DSBOM-creation-and-OWASP-Dependency-Track)) and uploaded to [Dependency Track](https://dependency-track-prod.jahia.com/)
-- [ ] 🔝 Review the security [vulnerabilities](https://sonarqube.jahia.com/issues?resolved=false&types=VULNERABILITY) and [hotspots](https://sonarqube.jahia.com/security_hotspots?id=org.jahia.server%3Ajahia-root) affecting this codebase and discuss with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
+- [ ] 🔝 I've reviewed the security [vulnerabilities](https://sonarqube.jahia.com/issues?resolved=false&types=VULNERABILITY) and [hotspots](https://sonarqube.jahia.com/security_hotspots?id=org.jahia.server%3Ajahia-root) affecting this codebase and discussed it with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
+- [ ] 🔝 I've reviewed the [vulnerabilities](https://dependency-track-prod.jahia.com/login?redirect=%2Fprojects) affecting the libraries used by the module (related [documentation](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2079156/Analyzing+vulnerabilities+in+3rd+party+libraries)) and discussed it with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
 - [ ] 🔝 A job running Sonar checks (including OWASP Dependency Check) is executed regularly
 ### QA / Automated Tests
 - [ ] 🚨 The codebase is compatible with the latest release of Jahia
@@ -110,9 +111,10 @@ This checklist is focused on our forked repositories
 - [ ] 🚨 I checked that we've documented why we're still using a fork of this library in [confluence](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2065402/Releasing+our+project+forks)
 ### Security
 - [ ] 🔝 I checked that there are no known security vulnerabilities affecting this codebase
+- [ ] 🔝 I've analyzed the [vulnerabilities](https://dependency-track-prod.jahia.com/login?redirect=%2Fprojects) (related [documentation](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2079156/Analyzing+vulnerabilities+in+3rd+party+libraries)) and discussed with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
 ### CI/CD
 - [ ] 🚨 The build and the release/publish workflows are configured (or at least documented in [confluence](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2065402/Releasing+our+project+forks))
 ### GitHub
-- [ ] 🟠 [Branch protection](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2067858/GitHub+Product+-+Ref+ISPOL08.A14025#Branch-protection) is enabled for the repository
+- [ ] 🚨 [Branch protection](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2067858/GitHub+Product+-+Ref+ISPOL08.A14025#Branch-protection) is enabled for the repository
 - [ ] **Automatically delete head branches** is selected in **Settings**
 - [ ] 🙏 Repository topics match are populated (at a minimum: "product" and "supported")

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -7,7 +7,7 @@ labels: ['Tech Day', 'Area:Tech']
 
 ---
 
-The goal of this ticket is to work on technical debt for a ticket within a fixed time window of 1 day.
+The goal of this ticket is to work on technical debt for a repository within a fixed time window of 1 day.
 
 ## Organizing of your day
 
@@ -35,8 +35,12 @@ Please fill the checklist available in this ticket, priorities are available as 
 This checklist is focused on a classic Jahia repository (module, app)
 
 ### General
-- [ ] 🚨 I reviewed all OPEN TECH tickets created for that codebase (using fixVersion=codebase-X.Y.Z-SNAPSHOT)
+- [ ] 🚨 I reviewed all OPEN TECH tickets created for that codebase (using codebase-X.Y.Z milestone)
 - [ ] 🚨 I reviewed older tech day tickets for that codebase
+- [ ] 🟠 Standards have been discussed in a tech kumite in the past semester
+### Dependency management
+- [ ] 🔝 I've identified the process/tools to handle dependency updates (ex: [renovate](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2071358/3rd-party+libraries+-+Ref+ISPOL08.A14024#%5BinlineExtension%5DRenovate))
+- [ ] 🙏 Remove unused libraries
 ### Javascript
 - [ ] 🔝 The module's webpack config is correct ([sample](https://github.com/Jahia/jcontent/blob/master/webpack.config.js))
 - [ ] 🔝 The module is using a supported LTS version of ([NodeJS](https://nodejs.org/en/about/previous-releases))
@@ -49,29 +53,36 @@ This checklist is focused on a classic Jahia repository (module, app)
 - [ ] 🟠 Dependencies listed in packages.json are no more than 2 major versions behind their latest release
 - [ ] 🟠 Linting is executed properly and show no warnings
 - [ ] 🟠 No warning are presents in the browser console when using the app
+- [ ] 🙏 Remove unreachable code
 ### Java
 - [ ] 🔝 Java dependencies are explicitly declared in the module's pom.xml
 - [ ] 🔝 Spring is not used in the module
 - [ ] 🔝 No warnings or errors are present when building the module locally or on GitHub Actions
 - [ ] 🟠 No code smell on [Sonarqube](https://sonarqube.jahia.com/projects) for the module
+- [ ] 🙏 Remove unreachable code
 ### Security
-- [ ] 🔝 Our security lead confirmed there are no known security vulnerabilities affecting this codebase
+- [ ] 🔝 Review the [security vulnerabilities](ndency-track-prod.jahia.com/projects) affecting this codebase and discuss with the Security lead before taking action (Create a [SECURITY](https://support.jahia.com/browse/SECURITY) ticket, Close as false-positive, etc.)
 ### QA
 - [ ] 🔝 Automated tests are using jahia-cypress for all utils functions
 - [ ] 🔝 The test framework is using page-object models published by other modules
 - [ ] 🔝 The test framework is publishing its own page-object models for use by others
+- [ ] 🟠 A manual-run workflow is available
 - [ ] 🙏 Automated tests are using a recent version of Cypress
 - [ ] 🙏 Automated tests are only relying on supported modules
 ### CI/CD
 - [ ] 🔝 The build and the release workflows use the JDK 11 image (only if Jahia Parent is set to 8.2.0.0+)
 - [ ] 🔝 GitHub Actions (nightlys and other workflows) are executed without warnings (such as depreciations)
 - [ ] 🙏 The latest version of the actions are used (including jahia-modules-action)
+- [ ] 🙏 The [reusable workflows](https://github.com/Jahia/jahia-modules-action/tree/main/.github/workflows) are used
 ### Documentation
+- [ ] 🔝 Readme.md is up-to-date (module purpose, technical details, configuration steps)
+- [ ] 🟠 A tech roadmap is available 
 - [ ] 🙏 Module's documentation available on the academy is up-to-date
+### Issues
+- [ ] 🟠 If the repository is public, review the issues/pull requests from the community and give feedback
 ### GitHub
 - [ ] 🟠 [Branch protection](https://confluence.jahia.com/display/PR/GitHub+%28Product%29+-+Ref+ISPOL08.A14025#GitHub(Product)RefISPOL08.A14025-Branchprotection) is enabled for the repository
 - [ ] **Automatically delete head branches** is selected in **Settings**
-- [ ] 🙏 The repository contains a README.md file
 - [ ] 🙏 Repository topics match are populated (at a minimum: "product" and "supported")
 - [ ] 🙏 Stale branches or branches older than 2 years (non-maintenance branches) have been removed
 

--- a/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/tech-day.md
@@ -76,7 +76,7 @@ This checklist is there to help you but is not exaustive, if some items are not 
 - [ ] 🔝 The test framework is using page-object models published by other modules
 - [ ] 🔝 The test framework is publishing its own page-object models for use by others
 - [ ] 🟠 A manual-run workflow is available
-- [ ] 🟠 Instructions and [test cases](https://jahia.testrail.net/index.php?/dashboard) are available to document how a release should be tested
+- [ ] 🟠 Instructions and [test cases](https://jahia.testrail.net/index.php?/dashboard) are available to document how a release should be tested (how to do the "sanity check" of this module)
 - [ ] 🙏 Automated tests are using a recent version of Cypress
 - [ ] 🙏 Automated tests are only relying on supported modules
 ### CI/CD


### PR DESCRIPTION
Hey everyone,

As discussed during the ownership discussion, this template will be the primary guidelines for the ownership topic. It aims at guiding you when working on your codebases.

The goal is to get a review from everyone in the product team and address any comments by end of March 2025.

If easier, the actual file can be looked at here: https://github.com/Jahia/.github/blob/new-tech-day-template/.github/ISSUE_TEMPLATE/custom_product/tech-day.md 