### PR TITLE
docs: manually test only minimum jahia version on module releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom_product/release.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/release.md
@@ -55,7 +55,7 @@ Module migration
 While Testing
 - [ ] No warnings or errors are present in the browser console when testing the module
 - [ ] No warnings or errors are present in Jahia logs when testing the module (incl. migration)
-- [ ] Verified tickets present in the release are actually included in the release artifact
+- [ ] Select a random set of fixes from the release and verify them on the minimum jahia-version
 
 After Testing
 - [ ] Tested combinations (Jahia versions, modules versions) are listed in this released ticket

--- a/.github/ISSUE_TEMPLATE/custom_product/release.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/release.md
@@ -46,7 +46,7 @@ The following combinations should be validated:
 
 General
 - [ ] Manual tests detailing testing steps for validating the release of this module are present on Testrail
-- [ ] Automated tests using the release artifacts were executed (also against latest release of jahia)
+- [ ] Automated tests using the release artifacts were executed against the oldest and newest release of Jahia
 
 Module migration
 - [ ] Upgrade from the previous released version of the module was tested

--- a/.github/ISSUE_TEMPLATE/custom_product/release.md
+++ b/.github/ISSUE_TEMPLATE/custom_product/release.md
@@ -30,8 +30,7 @@ Desired Jahia Version: 8.X.X.X
 In the testing matrix, always use the latest patch version of a particular release
 
 The following combinations should be validated:
- - Jahia 8.1.7.0
- - Jahia 8.2.1.0
+ - minimum Jahia version (according to the pom.xml)
 
 :information_source: If you are releasing for the main branch of a module, make sure to complete the checklist below when working on the ticket.
 
@@ -47,7 +46,7 @@ The following combinations should be validated:
 
 General
 - [ ] Manual tests detailing testing steps for validating the release of this module are present on Testrail
-- [ ] Automated tests using the release artifacts were executed
+- [ ] Automated tests using the release artifacts were executed (also against latest release of jahia)
 
 Module migration
 - [ ] Upgrade from the previous released version of the module was tested


### PR DESCRIPTION
### Description
...

### Checklist
#### Source code
- [ ] I've considered the implications on security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] I've considered the implications on performances
- [ ] I've considered the implications on migration
- [ ] I've considered the implications on code maintainability

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

#### Documentation
- [ ] I've provided inline documentation (Source code)
- [ ] I've provided internal documentation (README, Confluence)
- [ ] I've provided user-facing documentation (Academy)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
