### PR TITLE
ci: Remove archived repo (npm-templates-web-blue)

### DIFF
--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -162,7 +162,6 @@ patterns:
       - Jahia/news-qamf@master
       - Jahia/npm-jsx-templates-web-blue@main
       - Jahia/npm-solid-react-templateset-example@master
-      - Jahia/npm-templates-web-blue@main
       - Jahia/open-source@master
       - Jahia/opencode@main
       - Jahia/org.ops4j.pax.web@main


### PR DESCRIPTION
### Description
Remove [npm-templates-web-blue](https://github.com/Jahia/npm-templates-web-blue) from the list of repositories to sync up for the Github templates as the repository has been archived and is now read-only.

Similar to https://github.com/Jahia/.github/pull/100.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
