### PR TITLE
ci: Remove archived repo (static-assets-custom)

### DIFF
--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -201,7 +201,6 @@ patterns:
       - Jahia/skins@master
       - Jahia/spnego-authentication-valve@master
       - Jahia/spring-framework@main
-      - Jahia/static-assets-custom@main
       - Jahia/tags@master
       - Jahia/tasks@master
       - Jahia/templates-system@master


### PR DESCRIPTION
### Description
Remove [static-assets-custom](https://github.com/Jahia/static-assets-custom) from the list of repositories to sync up for the Github templates as the repository has been archived and is now read-only.

Similar to https://github.com/Jahia/.github/pull/100 and https://github.com/Jahia/.github/pull/101.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
