### PR TITLE
fix: adjusted tampermonkey script to reflect changes done in GitHub UI

### DIFF
--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GitHub Issue Jira Links
 // @namespace    http://tampermonkey.net/
-// @version      1.3
+// @version      1.4
 // @description  Add a section below the GitHub issue description with Jira tickets listed from the "Support tickets" field.
 // @author       Fgerthoffert
 // @match        https://github.com/*/*/issues/*
@@ -48,7 +48,7 @@
    function getTicketsFieldContent(project, ticketsFieldName) {
        let ticketsField;
        let fieldContent;
-       const projectFieldsEntries = Array.from(project.querySelector('div > ul > div > div').children);
+       const projectFieldsEntries = Array.from(project.querySelector('div > ul').children);
        for (const projectField of projectFieldsEntries) {
            if (projectField.textContent.includes(ticketsFieldName)) {
                console.log("Field: " + ticketsFieldName + " found in project")
@@ -57,7 +57,7 @@
        }
 
        if (ticketsField !== undefined) {
-           fieldContent = ticketsField.querySelector('li > button').textContent
+           fieldContent = ticketsField.querySelector('li > span > button').textContent
        }
        return fieldContent
    }

--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GitHub Issue Jira Links
 // @namespace    http://tampermonkey.net/
-// @version      1.4
+// @version      1.5
 // @description  Add a section below the GitHub issue description with Jira tickets listed from the "Support tickets" field.
 // @author       Fgerthoffert
 // @match        https://github.com/*/*/issues/*
@@ -66,7 +66,8 @@
         return ticketsFieldContent
             .trim()
             .split(',')
-            .map(ticket => ticket.trim());
+            .map(ticket => ticket.trim())
+            .filter(ticket => ticket.length > 0);
     }
 
     function createJiraSection(ticketIDs, jiraBaseURL) {


### PR DESCRIPTION
The addition of the "Jira Tickets" link stopped working at some point, following some changes in GitHub UI.

Verified this is now working:

![Screenshot 2025-05-07 at 10 38 58](https://github.com/user-attachments/assets/d2069227-afc3-42d4-8e34-e7116ad71144)

