### PR TITLE
chore: removed need triage label from tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -3,7 +3,6 @@ name: Epic
 about: Create an epic
 title: ''
 type: Epic
-projects: ["Jahia/18"]
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -2,7 +2,6 @@
 name: Other
 about: Create a GitHub issue without using a template
 title: ''
-labels: need-triage
 type: Task
 
 ---

--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -167,7 +167,6 @@ patterns:
       - Jahia/org.ops4j.pax.web@main
       - Jahia/OSGi-modules-samples@master
       - Jahia/personal-api-tokens@main
-      - Jahia/pm@main
       - Jahia/preview-cloud@main
       - Jahia/preview-env@master
       - Jahia/profile@master

--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -95,6 +95,7 @@ patterns:
       - Jahia/github-actions-runners@v5.17.0
       - Jahia/graphql-core@master
       - Jahia/graphql-java-servlet@master
+      - Jahia/guest-multipart-filter@main      
       - Jahia/html-filtering@main
       - Jahia/izpack@4.3
       - Jahia/jaas-authentication-valve@master

--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -35,6 +35,7 @@ patterns:
       # from the list based on topics, make sure to remove them:
       # - Jahia/.github => This is the current repository
       # - Jahia/jahia => This is a clone of jahia-private
+      # - Jahia/pm => The repo used by PM for their internal issues
       - Jahia/advanced-visibility@master
       - Jahia/app-shell@master
       - Jahia/asset-webpack-example@main

--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -65,6 +65,7 @@ patterns:
       - Jahia/database-connector@master
       - Jahia/default@master
       - Jahia/deleted-issues@main
+      - Jahia/delivery@main
       - Jahia/df-tests-api@master
       - Jahia/directive-filter@master
       - Jahia/distributed-sessions@master

--- a/.github/workflows/delivery-list-cloud-repos.yml
+++ b/.github/workflows/delivery-list-cloud-repos.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get Cloud Repositories
         id: get-repos
-        uses: fgerthoffert/actions-get-org-repos@v1.0.0
+        uses: fgerthoffert/actions-get-org-repos@v1.3.0
         with:
           org: jahia
           max_query_nodes: 10

--- a/.github/workflows/delivery-list-community-repos.yml
+++ b/.github/workflows/delivery-list-community-repos.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get Org Repositories
         id: get-repos
-        uses: fgerthoffert/actions-get-org-repos@v1.0.0
+        uses: fgerthoffert/actions-get-org-repos@v1.3.0
         with:
           org: jahia
           max_query_nodes: 10

--- a/.github/workflows/delivery-list-product-repos.yml
+++ b/.github/workflows/delivery-list-product-repos.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get Org Repositories
         id: get-repos
-        uses: fgerthoffert/actions-get-org-repos@v1.0.0
+        uses: fgerthoffert/actions-get-org-repos@v1.3.0
         with:
           org: jahia
           token: ${{ secrets.GH_ISSUES_PRS_CHORES }}


### PR DESCRIPTION
Following discussion with @rknj @romain-pm @ffffffelix , we decided:
- to remove the automated need-triage label on tasks.
- to remove the auto config sync for issues in the pm repo

I removed the Projects field from the epic.md file since this parameter is only working for yaml templates, not MD

Also took the opportunity of the PR to refresh the list of repos