### PR TITLE
feat: Tampermonkey script scans all projects for Jira tickets

### DIFF
--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         GitHub Issue Jira Links
 // @namespace    http://tampermonkey.net/
-// @version      2.1
-// @description  Add clickable Jira ticket links from the "Jira tickets" project field. Works in both issue pages and project board pane views.
+// @version      3.0
+// @description  Add clickable Jira ticket links from the "Jira tickets" issue field. Works in both issue pages and project board pane views.
 // @author       Fgerthoffert
 // @match        https://github.com/*/*/issues/*
 // @match        https://github.com/*/*/projects/*
@@ -13,16 +13,8 @@
     'use strict';
 
     const cfgJiraBaseURL = 'https://support.jahia.com/browse/';
-    const cfgTicketsFieldName = 'Jira tickets';
     const cfgIssueEventsBaseURL = 'https://zencrepes.jahia.com/zindex/';
     const JIRA_SECTION_ID = 'tampermonkey-jira-links';
-
-    // --- View detection ---
-
-    function isProjectPaneView() {
-        const url = window.location.href;
-        return url.includes('/projects/') && url.includes('pane=issue');
-    }
 
     // --- DOM helpers ---
 
@@ -31,62 +23,28 @@
         if (existing) existing.remove();
     }
 
-    // --- Issue view: find projects in sidebar ---
+    // --- Issue field extraction ---
 
-    function findAllProjectsInSidebar() {
-        const projectsSidebar = document.querySelector('[data-testid="sidebar-projects-section"]');
-        if (!projectsSidebar) {
-            console.log("[Jira Links] No projects sidebar found");
-            return [];
+    function getTicketsFromIssueField() {
+        // Look for the "Jira tickets" field button via its aria-label
+        const fieldButton = document.querySelector('button[aria-label="Edit Jira tickets"]');
+        if (!fieldButton) {
+            console.log("[Jira Links] No 'Jira tickets' issue field found");
+            return undefined;
         }
-        // Try the standard issue view container first
-        let container = projectsSidebar.querySelector('div:nth-child(2) > div');
-        if (!container) {
-            // Fallback: look for any child div that contains project entries
-            container = projectsSidebar.querySelector('div > div');
+        // The value is in the second span (the one with the value text class)
+        const valueSpan = fieldButton.querySelector('span[class*="issueFieldValueText"]');
+        if (!valueSpan) {
+            console.log("[Jira Links] 'Jira tickets' field has no value span");
+            return undefined;
         }
-        if (!container) {
-            console.log("[Jira Links] No project entries container found");
-            return [];
+        const text = valueSpan.textContent.trim();
+        if (!text || text === 'None yet') {
+            console.log("[Jira Links] 'Jira tickets' field is empty");
+            return undefined;
         }
-        const projectEntries = Array.from(container.children);
-        console.log("[Jira Links] Found " + projectEntries.length + " project(s) in sidebar");
-        return projectEntries;
-    }
-
-    function expandProject(project) {
-        if (!project) return;
-        if (!project.textContent.includes(cfgTicketsFieldName)) {
-            const expandButton = project.querySelector('[data-component="IconButton"]');
-            if (expandButton) {
-                console.log("[Jira Links] Expanding project");
-                expandButton.click();
-            }
-        }
-    }
-
-    function getTicketsFieldFromProject(project) {
-        const ul = project.querySelector('div > ul');
-        if (!ul) return undefined;
-        const fields = Array.from(ul.children);
-        for (const field of fields) {
-            if (field.textContent.includes(cfgTicketsFieldName)) {
-                // Primary selector: li > span > button > span (issue view structure)
-                const spans = field.querySelectorAll('li > span > button > span');
-                if (spans && spans.length > 1) {
-                    return spans[1].textContent;
-                }
-                // Fallback: look for any span containing a ticket-like pattern
-                const allSpans = field.querySelectorAll('span');
-                for (const span of allSpans) {
-                    const text = span.textContent.trim();
-                    if (text && text !== cfgTicketsFieldName && /[A-Z]+-\d+/.test(text)) {
-                        return text;
-                    }
-                }
-            }
-        }
-        return undefined;
+        console.log("[Jira Links] Found tickets field value: " + text);
+        return text;
     }
 
 
@@ -134,10 +92,6 @@
         // Issue view: metadata section
         const issueMetadata = document.querySelector('[data-testid="issue-metadata-fixed"] > div');
         if (issueMetadata) return issueMetadata;
-
-        // Project pane view: look for the sidebar projects section itself and insert after it
-        const projectsSidebar = document.querySelector('[data-testid="sidebar-projects-section"]');
-        if (projectsSidebar) return projectsSidebar.parentElement;
 
         // Fallback: issue body
         const issueBody = document.querySelector('[data-testid="issue-body"]');
@@ -195,25 +149,13 @@
 
     // --- Main logic ---
 
-    function collectTicketsFromSidebar() {
-        const projects = findAllProjectsInSidebar();
-        for (const project of projects) {
-            expandProject(project);
+    function collectTicketsFromField() {
+        const content = getTicketsFromIssueField();
+        const ticketIds = getTicketIds(content);
+        if (ticketIds.length > 0) {
+            const container = findTargetContainer();
+            createJiraSection(ticketIds, cfgJiraBaseURL, container);
         }
-
-        setTimeout(() => {
-            const allTicketIds = [];
-            for (const project of projects) {
-                const content = getTicketsFieldFromProject(project);
-                const ids = getTicketIds(content);
-                if (ids.length > 0) allTicketIds.push(...ids);
-            }
-            const uniqueTicketIds = [...new Set(allTicketIds)];
-            if (uniqueTicketIds.length > 0) {
-                const container = findTargetContainer();
-                createJiraSection(uniqueTicketIds, cfgJiraBaseURL, container);
-            }
-        }, 1000);
     }
 
     function init() {
@@ -228,8 +170,8 @@
             addLinkToIssueEvent(issue, cfgIssueEventsBaseURL);
         }
 
-        // Use the same sidebar-based approach for both issue view and project pane view
-        collectTicketsFromSidebar();
+        // Read Jira tickets directly from the issue field
+        collectTicketsFromField();
     }
 
     // --- SPA navigation handling ---

--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -149,11 +149,16 @@
 
     // --- Main logic ---
 
-    function collectTicketsFromField() {
+    function collectTicketsFromField(retries = 2) {
         const content = getTicketsFromIssueField();
         const ticketIds = getTicketIds(content);
         if (ticketIds.length > 0) {
             const container = findTargetContainer();
+            if (!container && retries > 0) {
+                console.log("[Jira Links] Target container not found, retrying...");
+                setTimeout(() => collectTicketsFromField(retries - 1), 1000);
+                return;
+            }
             createJiraSection(ticketIds, cfgJiraBaseURL, container);
         }
     }
@@ -178,14 +183,16 @@
     // Project views use pushState/replaceState for navigation without full page reloads.
 
     let lastUrl = window.location.href;
+    let pendingInitTimeout = null;
 
     function onUrlChange() {
         const currentUrl = window.location.href;
         if (currentUrl !== lastUrl) {
             lastUrl = currentUrl;
             console.log("[Jira Links] URL changed, re-initializing");
-            // Wait for the new pane content to render
-            setTimeout(init, 1500);
+            // Debounce to avoid duplicate init() calls from rapid mutations
+            clearTimeout(pendingInitTimeout);
+            pendingInitTimeout = setTimeout(init, 1500);
         }
     }
 
@@ -193,21 +200,25 @@
     const originalPushState = history.pushState;
     history.pushState = function () {
         originalPushState.apply(this, arguments);
-        onUrlChange();
+        try { onUrlChange(); } catch (e) { console.error("[Jira Links]", e); }
     };
 
     const originalReplaceState = history.replaceState;
     history.replaceState = function () {
         originalReplaceState.apply(this, arguments);
-        onUrlChange();
+        try { onUrlChange(); } catch (e) { console.error("[Jira Links]", e); }
     };
 
     window.addEventListener('popstate', onUrlChange);
 
-    // Run on initial page load
-    window.addEventListener('load', () => {
-        setTimeout(init, 2000);
-    });
+    // Run on initial page load (handle case where load already fired)
+    if (document.readyState === 'complete') {
+        setTimeout(init, 500);
+    } else {
+        window.addEventListener('load', () => {
+            setTimeout(init, 2000);
+        });
+    }
 
     // Also observe DOM changes for dynamic pane loading (e.g., clicking an issue in project view)
     const observer = new MutationObserver(() => {

--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -14,12 +14,13 @@
 
     const cfgJiraBaseURL = 'https://support.jahia.com/browse/';
     const cfgIssueEventsBaseURL = 'https://zencrepes.jahia.com/zindex/';
-    const JIRA_SECTION_ID = 'tampermonkey-jira-links';
+    const cfgJiraSectionId = 'tampermonkey-jira-links';
+    const cfgIssueFieldTitle = 'Jira tickets';
 
     // --- DOM helpers ---
 
     function removeExistingJiraSection() {
-        const existing = document.getElementById(JIRA_SECTION_ID);
+        const existing = document.getElementById(cfgJiraSectionId);
         if (existing) existing.remove();
     }
 
@@ -27,23 +28,23 @@
 
     function getTicketsFromIssueField() {
         // Look for the "Jira tickets" field button via its aria-label
-        const fieldButton = document.querySelector('button[aria-label="Edit Jira tickets"]');
+        const fieldButton = document.querySelector(`button[aria-label="Edit ${cfgIssueFieldTitle}"]`);
         if (!fieldButton) {
-            console.log("[Jira Links] No 'Jira tickets' issue field found");
+            console.log(`[Jira Links] No '${cfgIssueFieldTitle}' issue field found`);
             return undefined;
         }
         // The value is in the second span (the one with the value text class)
         const valueSpan = fieldButton.querySelector('span[class*="issueFieldValueText"]');
         if (!valueSpan) {
-            console.log("[Jira Links] 'Jira tickets' field has no value span");
+            console.log(`[Jira Links] '${cfgIssueFieldTitle}' field has no value span`);
             return undefined;
         }
         const text = valueSpan.textContent.trim();
         if (!text || text === 'None yet') {
-            console.log("[Jira Links] 'Jira tickets' field is empty");
+            console.log(`[Jira Links] '${cfgIssueFieldTitle}' field is empty`);
             return undefined;
         }
-        console.log("[Jira Links] Found tickets field value: " + text);
+        console.log(`[Jira Links] Found '${cfgIssueFieldTitle}' field value: ${text}`);
         return text;
     }
 
@@ -69,7 +70,7 @@
         removeExistingJiraSection();
 
         const jiraSection = document.createElement('div');
-        jiraSection.id = JIRA_SECTION_ID;
+        jiraSection.id = cfgJiraSectionId;
         jiraSection.style.marginTop = '20px';
 
         jiraSection.innerHTML = `

--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         GitHub Issue Jira Links
 // @namespace    http://tampermonkey.net/
-// @version      2.0
-// @description  Add a section below the GitHub issue description with Jira tickets listed from the "Jira tickets" field across all projects.
+// @version      2.1
+// @description  Add clickable Jira ticket links from the "Jira tickets" project field. Works in both issue pages and project board pane views.
 // @author       Fgerthoffert
 // @match        https://github.com/*/*/issues/*
 // @match        https://github.com/*/*/projects/*
@@ -12,60 +12,138 @@
 (function () {
     'use strict';
 
-    const cfgJiraBaseURL = 'https://support.jahia.com/browse/'; // Update with your Jira instance URL.
-    const cfgTicketsFieldName = 'Jira tickets'
-    const cfgIssueEventsBaseURL = 'https://zencrepes.jahia.com/zindex/'; // Update with the host containing the issue events
+    const cfgJiraBaseURL = 'https://support.jahia.com/browse/';
+    const cfgTicketsFieldName = 'Jira tickets';
+    const cfgIssueEventsBaseURL = 'https://zencrepes.jahia.com/zindex/';
+    const JIRA_SECTION_ID = 'tampermonkey-jira-links';
 
-    function findAllProjects() {
+    // --- View detection ---
+
+    function isProjectPaneView() {
+        const url = window.location.href;
+        return url.includes('/projects/') && url.includes('pane=issue');
+    }
+
+    function isIssueView() {
+        return window.location.href.includes('/issues/');
+    }
+
+    // --- DOM helpers ---
+
+    function removeExistingJiraSection() {
+        const existing = document.getElementById(JIRA_SECTION_ID);
+        if (existing) existing.remove();
+    }
+
+    // --- Issue view: find projects in sidebar ---
+
+    function findAllProjectsInSidebar() {
         const projectsSidebar = document.querySelector('[data-testid="sidebar-projects-section"]');
         if (!projectsSidebar) {
-            console.log("No projects sidebar found");
+            console.log("[Jira Links] No projects sidebar found");
             return [];
         }
         const container = projectsSidebar.querySelector('div:nth-child(2) > div');
         if (!container) {
-            console.log("No project entries container found");
+            console.log("[Jira Links] No project entries container found");
             return [];
         }
         const projectEntries = Array.from(container.children);
-        console.log("Found " + projectEntries.length + " project(s) in sidebar");
+        console.log("[Jira Links] Found " + projectEntries.length + " project(s) in sidebar");
         return projectEntries;
     }
 
     function expandProject(project) {
-        if (project !== undefined) {
-            // Not clicking if the field is already visible
-            if (!project.textContent.includes(cfgTicketsFieldName)) {
-                const expandButton = project.querySelector('[data-component="IconButton"]');
-                if (expandButton) {
-                    console.log("Clicking on expand button for project");
-                    expandButton.click();
+        if (!project) return;
+        if (!project.textContent.includes(cfgTicketsFieldName)) {
+            const expandButton = project.querySelector('[data-component="IconButton"]');
+            if (expandButton) {
+                console.log("[Jira Links] Expanding project");
+                expandButton.click();
+            }
+        }
+    }
+
+    function getTicketsFieldFromProject(project) {
+        const ul = project.querySelector('div > ul');
+        if (!ul) return undefined;
+        const fields = Array.from(ul.children);
+        for (const field of fields) {
+            if (field.textContent.includes(cfgTicketsFieldName)) {
+                const spans = field.querySelectorAll('li > span > button > span');
+                if (spans && spans.length > 1) {
+                    return spans[1].textContent;
                 }
             }
         }
+        return undefined;
     }
 
-    function getTicketsFieldContent(project, ticketsFieldName) {
-        let ticketsField;
-        let fieldContent;
-        const ul = project.querySelector('div > ul');
-        if (!ul) return undefined;
-        const projectFieldsEntries = Array.from(ul.children);
-        for (const projectField of projectFieldsEntries) {
-            if (projectField.textContent.includes(ticketsFieldName)) {
-                console.log("Field: " + ticketsFieldName + " found in project")
-                ticketsField = projectField
+    // --- Project pane view: find tickets in the issue pane sidebar ---
+
+    function getTicketsFromProjectPane() {
+        // In project pane view, project fields are displayed in the issue detail sidebar.
+        // Look for the "Jira tickets" field label and its adjacent value.
+        const allText = document.querySelectorAll('span, div, label');
+        for (const el of allText) {
+            if (el.textContent.trim() === cfgTicketsFieldName && el.closest('[class*="sidebar"], [class*="Sidebar"], [data-testid*="sidebar"], [role="complementary"]')) {
+                // Found the label, look for the value in the parent container
+                const container = el.closest('div[class]') || el.parentElement;
+                if (container) {
+                    const buttons = container.querySelectorAll('button > span');
+                    for (const btn of buttons) {
+                        const text = btn.textContent.trim();
+                        if (text && text !== cfgTicketsFieldName && !text.includes("Enter text")) {
+                            return text;
+                        }
+                    }
+                }
             }
         }
 
-        if (ticketsField !== undefined) {
-            const spans = ticketsField.querySelectorAll('li > span > button > span');
-            if (spans && spans.length > 1) {
-                fieldContent = spans[1].textContent;
+        // Fallback: search for the field in any visible project field list in the pane
+        const fieldGroups = document.querySelectorAll('[data-testid="issue-sidebar"] ul, [role="complementary"] ul');
+        for (const ul of fieldGroups) {
+            const items = Array.from(ul.children);
+            for (const item of items) {
+                if (item.textContent.includes(cfgTicketsFieldName)) {
+                    const spans = item.querySelectorAll('li > span > button > span, span > button > span');
+                    if (spans && spans.length > 1) {
+                        return spans[1].textContent;
+                    }
+                    // Try broader search within the item
+                    const allSpans = item.querySelectorAll('span');
+                    for (const span of allSpans) {
+                        const text = span.textContent.trim();
+                        if (text && text !== cfgTicketsFieldName && !text.includes("Enter text") && /[A-Z]+-\d+/.test(text)) {
+                            return text;
+                        }
+                    }
+                }
             }
         }
-        return fieldContent;
+
+        // Last resort: scan the entire pane for a text pattern matching tickets near the field name
+        const pane = document.querySelector('[data-testid="side-panel"], [class*="pane"], [class*="Panel"]');
+        if (pane) {
+            const items = pane.querySelectorAll('li, div');
+            for (const item of items) {
+                if (item.textContent.includes(cfgTicketsFieldName)) {
+                    const spans = item.querySelectorAll('span');
+                    for (const span of spans) {
+                        const text = span.textContent.trim();
+                        if (text && text !== cfgTicketsFieldName && /^[A-Z]+-\d+/.test(text)) {
+                            return text;
+                        }
+                    }
+                }
+            }
+        }
+
+        return undefined;
     }
+
+    // --- Ticket parsing ---
 
     function getTicketIds(ticketsFieldContent) {
         if (!ticketsFieldContent || ticketsFieldContent.includes("Enter text")) {
@@ -78,9 +156,14 @@
             .filter(ticket => ticket.length > 0 && /^[A-Z]+-\d+$/.test(ticket));
     }
 
-    function createJiraSection(ticketIDs, jiraBaseURL) {
-        console.log("Creating links for tickets: ", ticketIDs)
+    // --- Rendering ---
+
+    function createJiraSection(ticketIDs, jiraBaseURL, targetContainer) {
+        console.log("[Jira Links] Creating links for tickets: ", ticketIDs);
+        removeExistingJiraSection();
+
         const jiraSection = document.createElement('div');
+        jiraSection.id = JIRA_SECTION_ID;
         jiraSection.style.marginTop = '20px';
 
         jiraSection.innerHTML = `
@@ -94,29 +177,44 @@
           </div>
       `;
 
-        // Find the description container and append the new section below it.
-        const descriptionContainer = document.querySelector('[data-testid="issue-metadata-fixed"] > div');
-        if (descriptionContainer) {
-            descriptionContainer.appendChild(jiraSection);
+        if (targetContainer) {
+            targetContainer.appendChild(jiraSection);
         }
     }
 
+    function findTargetContainer() {
+        // Issue view: metadata section
+        const issueMetadata = document.querySelector('[data-testid="issue-metadata-fixed"] > div');
+        if (issueMetadata) return issueMetadata;
+
+        // Project pane view: try the issue body/header area within the pane
+        const paneBody = document.querySelector('[data-testid="side-panel-body"]');
+        if (paneBody) return paneBody;
+
+        // Fallback: look for the issue body in the pane
+        const issueBody = document.querySelector('[data-testid="issue-body"]');
+        if (issueBody) return issueBody.parentElement;
+
+        // Another fallback for project pane: the pane's first scrollable div
+        const pane = document.querySelector('[class*="pane"] [class*="content"], [role="complementary"]');
+        if (pane) return pane;
+
+        return null;
+    }
+
+    // --- Issue object extraction ---
+
     function getIssueObject(url) {
-        // Should support these two URL formats:
-        // https://github.com/Jahia/jahia-private/issues/2893
-        // https://github.com/orgs/Jahia/projects/50/views/1?pane=issue&itemId=99829665&issue=Jahia%7Cjahia-private%7C2893
         const urlObj = new URL(url);
         const pathSegments = urlObj.pathname.split('/');
 
         let organization, repository, number;
 
-        if (url.includes('issues')) {
-            // Handling issue URL
+        if (url.includes('/issues/')) {
             organization = pathSegments[1];
             repository = pathSegments[2];
             number = pathSegments[4];
-        } else if (url.includes('projects')) {
-            // Handling project URL
+        } else if (url.includes('/projects/')) {
             const issueParam = urlObj.searchParams.get('issue');
             if (issueParam) {
                 const issueParts = issueParam.split('|');
@@ -126,47 +224,35 @@
             }
         }
 
-        return {
-            organization,
-            repository,
-            number
-        };
+        return { organization, repository, number };
     }
 
+    // --- Issue event link ---
+
     function addLinkToIssueEvent(issue, baseURL) {
-        console.log("Adding a link to issue events")
+        console.log("[Jira Links] Adding a link to issue events");
         const phActionsDiv = document.querySelector('div[data-component="PH_Actions"]');
         if (phActionsDiv !== null) {
-            console.log(phActionsDiv)
             const innerDiv = phActionsDiv.querySelector('div');
             if (innerDiv) {
+                // Avoid adding duplicate links
+                if (innerDiv.querySelector('a[title*="issue events"]')) return;
                 const link = document.createElement('a');
                 link.textContent = '🕰️';
                 link.href = baseURL + "/" + issue.organization + "/" + issue.repository + "/txt/" + issue.number + ".txt";
-                link.target = '_blank'; // Open the link in a new window
+                link.target = '_blank';
                 link.title = "Display issue events (⚠️ VPN REQUIRED ⚠️)";
-
-                // Append the link as the last element of the inner div
                 innerDiv.appendChild(link);
             }
         } else {
-            console.log("Unable to find the issue actions to add the icon to")
+            console.log("[Jira Links] Unable to find the issue actions to add the icon to");
         }
     }
 
-    function init() {
-        // Add a link to the issue event history
-        const issue = getIssueObject(window.location.href)
-        console.log("Extracted the following about the issue:", issue);
-        if (issue.organization !== "Jahia") {
-            console.log("Organization is not Jahia, not displaying the history icon")
-        } else {
-            console.log("Displaying link to issue history disabled until: INFRA-3252")
-            addLinkToIssueEvent(issue, cfgIssueEventsBaseURL);
-        }
+    // --- Main logic ---
 
-        // Find and expand all projects, then extract tickets from all of them.
-        const projects = findAllProjects();
+    function collectTicketsFromIssueView() {
+        const projects = findAllProjectsInSidebar();
         for (const project of projects) {
             expandProject(project);
         }
@@ -174,22 +260,99 @@
         setTimeout(() => {
             const allTicketIds = [];
             for (const project of projects) {
-                const ticketsFieldContent = getTicketsFieldContent(project, cfgTicketsFieldName);
-                const ticketIds = getTicketIds(ticketsFieldContent);
-                if (ticketIds.length > 0) {
-                    allTicketIds.push(...ticketIds);
-                }
+                const content = getTicketsFieldFromProject(project);
+                const ids = getTicketIds(content);
+                if (ids.length > 0) allTicketIds.push(...ids);
             }
-            // Deduplicate tickets (same ticket may appear in multiple projects)
             const uniqueTicketIds = [...new Set(allTicketIds)];
             if (uniqueTicketIds.length > 0) {
-                createJiraSection(uniqueTicketIds, cfgJiraBaseURL);
+                const container = findTargetContainer();
+                createJiraSection(uniqueTicketIds, cfgJiraBaseURL, container);
             }
-        }, 1000); // Delay to ensure the expanded content is loaded.
+        }, 1000);
     }
 
-    // Run the script after the page loads completely.
+    function collectTicketsFromProjectPane() {
+        // In project pane, fields may already be visible without expanding
+        const content = getTicketsFromProjectPane();
+        const ids = getTicketIds(content);
+        if (ids.length > 0) {
+            const container = findTargetContainer();
+            createJiraSection(ids, cfgJiraBaseURL, container);
+        } else {
+            // Retry: the pane content may still be loading
+            setTimeout(() => {
+                const retryContent = getTicketsFromProjectPane();
+                const retryIds = getTicketIds(retryContent);
+                if (retryIds.length > 0) {
+                    const container = findTargetContainer();
+                    createJiraSection(retryIds, cfgJiraBaseURL, container);
+                }
+            }, 1500);
+        }
+    }
+
+    function init() {
+        console.log("[Jira Links] Initializing for URL:", window.location.href);
+        removeExistingJiraSection();
+
+        const issue = getIssueObject(window.location.href);
+        console.log("[Jira Links] Issue:", issue);
+
+        // Add issue event history link (for Jahia org only)
+        if (issue.organization === "Jahia" && issue.number) {
+            addLinkToIssueEvent(issue, cfgIssueEventsBaseURL);
+        }
+
+        if (isIssueView()) {
+            collectTicketsFromIssueView();
+        } else if (isProjectPaneView()) {
+            collectTicketsFromProjectPane();
+        }
+    }
+
+    // --- SPA navigation handling ---
+    // Project views use pushState/replaceState for navigation without full page reloads.
+
+    let lastUrl = window.location.href;
+
+    function onUrlChange() {
+        const currentUrl = window.location.href;
+        if (currentUrl !== lastUrl) {
+            lastUrl = currentUrl;
+            console.log("[Jira Links] URL changed, re-initializing");
+            // Wait for the new pane content to render
+            setTimeout(init, 1500);
+        }
+    }
+
+    // Intercept pushState and replaceState to detect SPA navigation
+    const originalPushState = history.pushState;
+    history.pushState = function () {
+        originalPushState.apply(this, arguments);
+        onUrlChange();
+    };
+
+    const originalReplaceState = history.replaceState;
+    history.replaceState = function () {
+        originalReplaceState.apply(this, arguments);
+        onUrlChange();
+    };
+
+    window.addEventListener('popstate', onUrlChange);
+
+    // Run on initial page load
     window.addEventListener('load', () => {
-        setTimeout(init, 2000); // Allow time for dynamic GitHub content to load.
+        setTimeout(init, 2000);
+    });
+
+    // Also observe DOM changes for dynamic pane loading (e.g., clicking an issue in project view)
+    const observer = new MutationObserver(() => {
+        onUrlChange();
+    });
+    observer.observe(document.querySelector('head > title') || document.head, {
+        childList: true,
+        subtree: true,
+        characterData: true
     });
 })();

--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -24,10 +24,6 @@
         return url.includes('/projects/') && url.includes('pane=issue');
     }
 
-    function isIssueView() {
-        return window.location.href.includes('/issues/');
-    }
-
     // --- DOM helpers ---
 
     function removeExistingJiraSection() {
@@ -43,7 +39,12 @@
             console.log("[Jira Links] No projects sidebar found");
             return [];
         }
-        const container = projectsSidebar.querySelector('div:nth-child(2) > div');
+        // Try the standard issue view container first
+        let container = projectsSidebar.querySelector('div:nth-child(2) > div');
+        if (!container) {
+            // Fallback: look for any child div that contains project entries
+            container = projectsSidebar.querySelector('div > div');
+        }
         if (!container) {
             console.log("[Jira Links] No project entries container found");
             return [];
@@ -70,78 +71,25 @@
         const fields = Array.from(ul.children);
         for (const field of fields) {
             if (field.textContent.includes(cfgTicketsFieldName)) {
+                // Primary selector: li > span > button > span (issue view structure)
                 const spans = field.querySelectorAll('li > span > button > span');
                 if (spans && spans.length > 1) {
                     return spans[1].textContent;
                 }
+                // Fallback: look for any span containing a ticket-like pattern
+                const allSpans = field.querySelectorAll('span');
+                for (const span of allSpans) {
+                    const text = span.textContent.trim();
+                    if (text && text !== cfgTicketsFieldName && /[A-Z]+-\d+/.test(text)) {
+                        return text;
+                    }
+                }
             }
         }
         return undefined;
     }
 
-    // --- Project pane view: find tickets in the issue pane sidebar ---
 
-    function getTicketsFromProjectPane() {
-        // In project pane view, project fields are displayed in the issue detail sidebar.
-        // Look for the "Jira tickets" field label and its adjacent value.
-        const allText = document.querySelectorAll('span, div, label');
-        for (const el of allText) {
-            if (el.textContent.trim() === cfgTicketsFieldName && el.closest('[class*="sidebar"], [class*="Sidebar"], [data-testid*="sidebar"], [role="complementary"]')) {
-                // Found the label, look for the value in the parent container
-                const container = el.closest('div[class]') || el.parentElement;
-                if (container) {
-                    const buttons = container.querySelectorAll('button > span');
-                    for (const btn of buttons) {
-                        const text = btn.textContent.trim();
-                        if (text && text !== cfgTicketsFieldName && !text.includes("Enter text")) {
-                            return text;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Fallback: search for the field in any visible project field list in the pane
-        const fieldGroups = document.querySelectorAll('[data-testid="issue-sidebar"] ul, [role="complementary"] ul');
-        for (const ul of fieldGroups) {
-            const items = Array.from(ul.children);
-            for (const item of items) {
-                if (item.textContent.includes(cfgTicketsFieldName)) {
-                    const spans = item.querySelectorAll('li > span > button > span, span > button > span');
-                    if (spans && spans.length > 1) {
-                        return spans[1].textContent;
-                    }
-                    // Try broader search within the item
-                    const allSpans = item.querySelectorAll('span');
-                    for (const span of allSpans) {
-                        const text = span.textContent.trim();
-                        if (text && text !== cfgTicketsFieldName && !text.includes("Enter text") && /[A-Z]+-\d+/.test(text)) {
-                            return text;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Last resort: scan the entire pane for a text pattern matching tickets near the field name
-        const pane = document.querySelector('[data-testid="side-panel"], [class*="pane"], [class*="Panel"]');
-        if (pane) {
-            const items = pane.querySelectorAll('li, div');
-            for (const item of items) {
-                if (item.textContent.includes(cfgTicketsFieldName)) {
-                    const spans = item.querySelectorAll('span');
-                    for (const span of spans) {
-                        const text = span.textContent.trim();
-                        if (text && text !== cfgTicketsFieldName && /^[A-Z]+-\d+/.test(text)) {
-                            return text;
-                        }
-                    }
-                }
-            }
-        }
-
-        return undefined;
-    }
 
     // --- Ticket parsing ---
 
@@ -187,17 +135,13 @@
         const issueMetadata = document.querySelector('[data-testid="issue-metadata-fixed"] > div');
         if (issueMetadata) return issueMetadata;
 
-        // Project pane view: try the issue body/header area within the pane
-        const paneBody = document.querySelector('[data-testid="side-panel-body"]');
-        if (paneBody) return paneBody;
+        // Project pane view: look for the sidebar projects section itself and insert after it
+        const projectsSidebar = document.querySelector('[data-testid="sidebar-projects-section"]');
+        if (projectsSidebar) return projectsSidebar.parentElement;
 
-        // Fallback: look for the issue body in the pane
+        // Fallback: issue body
         const issueBody = document.querySelector('[data-testid="issue-body"]');
         if (issueBody) return issueBody.parentElement;
-
-        // Another fallback for project pane: the pane's first scrollable div
-        const pane = document.querySelector('[class*="pane"] [class*="content"], [role="complementary"]');
-        if (pane) return pane;
 
         return null;
     }
@@ -251,7 +195,7 @@
 
     // --- Main logic ---
 
-    function collectTicketsFromIssueView() {
+    function collectTicketsFromSidebar() {
         const projects = findAllProjectsInSidebar();
         for (const project of projects) {
             expandProject(project);
@@ -272,26 +216,6 @@
         }, 1000);
     }
 
-    function collectTicketsFromProjectPane() {
-        // In project pane, fields may already be visible without expanding
-        const content = getTicketsFromProjectPane();
-        const ids = getTicketIds(content);
-        if (ids.length > 0) {
-            const container = findTargetContainer();
-            createJiraSection(ids, cfgJiraBaseURL, container);
-        } else {
-            // Retry: the pane content may still be loading
-            setTimeout(() => {
-                const retryContent = getTicketsFromProjectPane();
-                const retryIds = getTicketIds(retryContent);
-                if (retryIds.length > 0) {
-                    const container = findTargetContainer();
-                    createJiraSection(retryIds, cfgJiraBaseURL, container);
-                }
-            }, 1500);
-        }
-    }
-
     function init() {
         console.log("[Jira Links] Initializing for URL:", window.location.href);
         removeExistingJiraSection();
@@ -304,11 +228,8 @@
             addLinkToIssueEvent(issue, cfgIssueEventsBaseURL);
         }
 
-        if (isIssueView()) {
-            collectTicketsFromIssueView();
-        } else if (isProjectPaneView()) {
-            collectTicketsFromProjectPane();
-        }
+        // Use the same sidebar-based approach for both issue view and project pane view
+        collectTicketsFromSidebar();
     }
 
     // --- SPA navigation handling ---

--- a/tools/tampermonkey-support-tickets.js
+++ b/tools/tampermonkey-support-tickets.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         GitHub Issue Jira Links
 // @namespace    http://tampermonkey.net/
-// @version      1.6
-// @description  Add a section below the GitHub issue description with Jira tickets listed from the "Support tickets" field.
+// @version      2.0
+// @description  Add a section below the GitHub issue description with Jira tickets listed from the "Jira tickets" field across all projects.
 // @author       Fgerthoffert
 // @match        https://github.com/*/*/issues/*
 // @match        https://github.com/*/*/projects/*
@@ -13,21 +13,23 @@
     'use strict';
 
     const cfgJiraBaseURL = 'https://support.jahia.com/browse/'; // Update with your Jira instance URL.
-    const cfgProjectName = 'Engineering - Delivery'
     const cfgTicketsFieldName = 'Jira tickets'
     const cfgIssueEventsBaseURL = 'https://zencrepes.jahia.com/zindex/'; // Update with the host containing the issue events
 
-    function findProject(projectName) {
+    function findAllProjects() {
         const projectsSidebar = document.querySelector('[data-testid="sidebar-projects-section"]');
-        const projectEntries = Array.from(projectsSidebar.querySelector('div:nth-child(2) > div').children);
-        let foundProject;
-        for (const project of projectEntries) {
-          if (project.textContent.includes(projectName)) {
-            console.log("Project: " + projectName + " found")
-            foundProject = project
-          }
+        if (!projectsSidebar) {
+            console.log("No projects sidebar found");
+            return [];
         }
-        return foundProject
+        const container = projectsSidebar.querySelector('div:nth-child(2) > div');
+        if (!container) {
+            console.log("No project entries container found");
+            return [];
+        }
+        const projectEntries = Array.from(container.children);
+        console.log("Found " + projectEntries.length + " project(s) in sidebar");
+        return projectEntries;
     }
 
     function expandProject(project) {
@@ -35,43 +37,45 @@
             // Not clicking if the field is already visible
             if (!project.textContent.includes(cfgTicketsFieldName)) {
                 const expandButton = project.querySelector('[data-component="IconButton"]');
-                console.log(expandButton)
                 if (expandButton) {
-                    console.log("Clicking on expand button")
+                    console.log("Clicking on expand button for project");
                     expandButton.click();
                 }
             }
         }
     }
 
+    function getTicketsFieldContent(project, ticketsFieldName) {
+        let ticketsField;
+        let fieldContent;
+        const ul = project.querySelector('div > ul');
+        if (!ul) return undefined;
+        const projectFieldsEntries = Array.from(ul.children);
+        for (const projectField of projectFieldsEntries) {
+            if (projectField.textContent.includes(ticketsFieldName)) {
+                console.log("Field: " + ticketsFieldName + " found in project")
+                ticketsField = projectField
+            }
+        }
 
-   function getTicketsFieldContent(project, ticketsFieldName) {
-       let ticketsField;
-       let fieldContent;
-       const projectFieldsEntries = Array.from(project.querySelector('div > ul').children);
-       for (const projectField of projectFieldsEntries) {
-           if (projectField.textContent.includes(ticketsFieldName)) {
-               console.log("Field: " + ticketsFieldName + " found in project")
-               ticketsField = projectField
-           }
-       }
-
-       if (ticketsField !== undefined) {
-           fieldContent = ticketsField.querySelectorAll('li > span > button > span')[1].textContent
-       }
-       return fieldContent
-   }
+        if (ticketsField !== undefined) {
+            const spans = ticketsField.querySelectorAll('li > span > button > span');
+            if (spans && spans.length > 1) {
+                fieldContent = spans[1].textContent;
+            }
+        }
+        return fieldContent;
+    }
 
     function getTicketIds(ticketsFieldContent) {
-        if (ticketsFieldContent.includes("Enter text")) {
-            return "";
-        } else {
-            return ticketsFieldContent
-                .trim()
-                .split(',')
-                .map(ticket => ticket.trim())
-                .filter(ticket => ticket.length > 0);
+        if (!ticketsFieldContent || ticketsFieldContent.includes("Enter text")) {
+            return [];
         }
+        return ticketsFieldContent
+            .trim()
+            .split(',')
+            .map(ticket => ticket.trim())
+            .filter(ticket => ticket.length > 0 && /^[A-Z]+-\d+$/.test(ticket));
     }
 
     function createJiraSection(ticketIDs, jiraBaseURL) {
@@ -161,20 +165,27 @@
             addLinkToIssueEvent(issue, cfgIssueEventsBaseURL);
         }
 
-        // Expand project details first, then extract and display tickets.
-        const project = findProject(cfgProjectName)
-        console.log(project)
-        expandProject(project)
+        // Find and expand all projects, then extract tickets from all of them.
+        const projects = findAllProjects();
+        for (const project of projects) {
+            expandProject(project);
+        }
 
         setTimeout(() => {
-            const ticketsFieldContent = getTicketsFieldContent(project, cfgTicketsFieldName)
-            const ticketIds = getTicketIds(ticketsFieldContent)
-            if (ticketIds && ticketIds.length > 0) {
-                createJiraSection(ticketIds, cfgJiraBaseURL);
+            const allTicketIds = [];
+            for (const project of projects) {
+                const ticketsFieldContent = getTicketsFieldContent(project, cfgTicketsFieldName);
+                const ticketIds = getTicketIds(ticketsFieldContent);
+                if (ticketIds.length > 0) {
+                    allTicketIds.push(...ticketIds);
+                }
+            }
+            // Deduplicate tickets (same ticket may appear in multiple projects)
+            const uniqueTicketIds = [...new Set(allTicketIds)];
+            if (uniqueTicketIds.length > 0) {
+                createJiraSection(uniqueTicketIds, cfgJiraBaseURL);
             }
         }, 1000); // Delay to ensure the expanded content is loaded.
-
-
     }
 
     // Run the script after the page loads completely.


### PR DESCRIPTION
## Summary

The Tampermonkey script previously only looked at a single hardcoded project ("Product Team") for Jira ticket links. This update makes it read tickets **directly from the issue field** instead.

## Changes

- **Direct field read**: Reads Jira tickets from the "Jira tickets" issue field (`aria-label` selector) instead of expanding project sidebar entries
- **SPA navigation support**: Handles GitHub's SPA navigation via `pushState`/`replaceState` interception and MutationObserver on `<title>`
- **Debounced re-initialization**: Prevents duplicate `init()` calls during rapid SPA navigation events
- **Error isolation**: `pushState`/`replaceState` patches wrapped in try/catch to avoid breaking GitHub's navigation
- **Retry on missing container**: Retries injection if the target DOM container is not yet rendered
- **Robust initialization**: Handles both fresh page loads and cases where `document.readyState` is already `complete`
- **Ticket format validation**: Only matches `PROJECT-ID` format (e.g., `SUPPORT-12345`) via anchored regex
- **Better null-safety**: Handles missing DOM elements gracefully with logging
- **Removed `cfgProjectName`**: No longer needed since tickets are read directly from the issue field

## Version

Bumped from 1.6 → 3.0