### PR TITLE
feat: Include content-versioning repository in sync

### DIFF
--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -4,16 +4,16 @@ settings:
     title: 'chore: sync files with `<%- repository %>` [skip ci]'
     labels:
       - chore
-    merge: 
+    merge:
       mode: admin
       strategy: squash
-      delete_branch: true      
-  commit: 
+      delete_branch: true
+  commit:
     format: '<%- prefix %>: <%- subject %>'
     prefix: 'chore'
     subject: 'sync files with `<%- repository %>` [skip ci]'
 patterns:
-  # Important, committing to the .github/workflows folder 
+  # Important, committing to the .github/workflows folder
   # require the user to have "workflow" scope on the token
   # https://github.com/octokit/rest.js/issues/368
   - files:
@@ -21,7 +21,7 @@ patterns:
       - from: .github/ISSUE_TEMPLATE
         to: .github/ISSUE_TEMPLATE
         exclude:
-          - '**/custom_*/*'        
+          - '**/custom_*/*'
       - from: .github/ISSUE_TEMPLATE/custom_product
         to: .github/ISSUE_TEMPLATE
       - .github/workflows/delivery-issue-chores.yml
@@ -34,7 +34,7 @@ patterns:
     delete_files:
       - .github/ISSUE_TEMPLATE/cloud-change-request.yml
     repositories:
-      # An updated version of this list can be obtained by running this 
+      # An updated version of this list can be obtained by running this
       # workflow: https://github.com/Jahia/.github/actions/workflows/delivery-list-product-repos.yml
       # IMPORTANT: The following repositories should not be synced
       # from the list based on topics, make sure to remove them:
@@ -64,6 +64,7 @@ patterns:
       - Jahia/cmis-provider@main
       - Jahia/content-editor@main
       - Jahia/content-security-policy@main
+      - Jahia/content-versioning@main
       - Jahia/contentRetrieval@main
       - Jahia/copy-to-other-languages@main
       - Jahia/core-perf-test@main
@@ -223,5 +224,4 @@ patterns:
       - Jahia/user-password-authentication@main
       - Jahia/visibility@main
       - Jahia/workato-unomi-connector@main
-      - Jahia/workflow-extender@main      
-
+      - Jahia/workflow-extender@main


### PR DESCRIPTION
Closes https://github.com/Jahia/content-versioning/issues/7.
### Description
Include the new https://github.com/Jahia/content-versioning repository (for https://github.com/Jahia/content-versioning/issues/30) in the synchronisation process.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
