### PR TITLE
chore: Remove content-editor (archived) from product file sync config

### DIFF
--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -62,7 +62,6 @@ patterns:
       - Jahia/cloudimage@main
       - Jahia/clustering@main
       - Jahia/cmis-provider@main
-      - Jahia/content-editor@main
       - Jahia/content-security-policy@main
       - Jahia/content-versioning@main
       - Jahia/contentRetrieval@main


### PR DESCRIPTION
### Description
Removed 'Jahia/content-editor@main' from the sync configuration.