### PR TITLE
feat: add on-pre-all-green workflow for all-checks gate

### DIFF
--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -30,6 +30,7 @@ patterns:
       - .github/workflows/docs-academy-publish.yml
       - .github/workflows/chachalog-comment-pr.yml
       - .github/workflows/chachalog-prepare-changelog.yml
+      - .github/workflows/on-pre-all-green.yml
       - .github/instructions/changelog.instructions.md
     delete_files:
       - .github/ISSUE_TEMPLATE/cloud-change-request.yml

--- a/.github/workflows/on-pre-all-green.yml
+++ b/.github/workflows/on-pre-all-green.yml
@@ -1,0 +1,13 @@
+# DO NOT EDIT
+# This file is managed globally at https://github.com/Jahia/.github
+name: All Checks Gate
+
+on:
+  check_suite:
+    types: [completed]
+  status: {}
+
+jobs:
+  all-green:
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-all-green.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds `on-pre-all-green.yml` workflow that calls the reusable `reusable-all-green.yml` workflow from `jahia-modules-action`. This provides a single gate check that turns green only when all other checks on a commit have passed.

## Changes

- **`.github/workflows/on-pre-all-green.yml`** — new workflow file with the standard "DO NOT EDIT" header
- **`.github/product-file-sync-config.yml`** — registers the new file for sync to all product repositories

## Dependency

This relies on [Jahia/jahia-modules-action#370](https://github.com/Jahia/jahia-modules-action/pull/370) being merged first.