### PR TITLE
feat(tools): add ViolentMonkey userscript and deprecate TamperMonkey

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,23 +1,40 @@
 This folder contains tools and scripts useful when using GitHub
 
-# TamperMonkey
+# Userscript: GitHub Issue Jira Links
 
-Using the script tampermonkey-support-tickets.js
-
-After installer the Chrome Extension "Tampermonkey", this script will build links to Jira tickets from the "Jira tickets" field in the Customers project.
+This script adds clickable Jira ticket links from the "Jira tickets" issue field in the Customers project. It works on both issue pages and project board pane views.
 
 <img src="./docs/link-jira-tickets.png" witdh= "800" />
 
-To install:
- - Install Tampermonkey chrome extension
- - Click on the "+" to add an extension
- - Copy/paste the content of the file.
+## Recommended: ViolentMonkey
 
-Troubleshooting:
-- I installed Tampermonkey and added the script, but it's not running.
-Ensure you enabled "Developer mode" under Google Chrome --> Extensions - Manage Extensions
-(You might need to restart your browser to make it effective.)
+[ViolentMonkey](https://violentmonkey.github.io) is a free and open-source userscript manager. It is the recommended extension for running this script.
+
+Use the script: `violentmonkey-support-tickets.js`
+
+To install:
+ - Install the [ViolentMonkey](https://violentmonkey.github.io/get-it/) browser extension
+ - Open the ViolentMonkey dashboard and click **+** → **New script**
+ - Paste the content of `violentmonkey-support-tickets.js` and save
+
+## Legacy: TamperMonkey (not recommended)
+
+> ⚠️ **Note:** Tampermonkey is closed-source software. We keep this script for reference only and do not recommend using it.
+
+The script `tampermonkey-support-tickets.js` remains available but is no longer maintained.
+
+<details>
+<summary>TamperMonkey install instructions (legacy)</summary>
+
+ - Install the Tampermonkey Chrome extension
+ - Click on the "+" to add a script
+ - Copy/paste the content of `tampermonkey-support-tickets.js`
+
+Troubleshooting: if the script is not running, ensure "Developer mode" is enabled under Chrome → Extensions → Manage Extensions and restart your browser.
+
 ![image](https://github.com/user-attachments/assets/b34b75f1-1ed0-4d98-80fd-3b8ccaafb10e)
+
+</details>
 
 # GitHub Issues notifications
 

--- a/tools/violentmonkey-support-tickets.js
+++ b/tools/violentmonkey-support-tickets.js
@@ -1,0 +1,234 @@
+// ==UserScript==
+// @name         GitHub Issue Jira Links
+// @namespace    https://github.com/Jahia/.github
+// @version      1.0
+// @description  Add clickable Jira ticket links from the "Jira tickets" issue field. Works in both issue pages and project board pane views.
+// @author       Fgerthoffert
+// @match        https://github.com/*/*/issues/*
+// @match        https://github.com/*/*/projects/*
+// @grant        none
+// @run-at       document-end
+// ==/UserScript==
+
+(function () {
+    'use strict';
+
+    const cfgJiraBaseURL = 'https://support.jahia.com/browse/';
+    const cfgIssueEventsBaseURL = 'https://zencrepes.jahia.com/zindex/';
+    const cfgJiraSectionId = 'vm-jira-links';
+    const cfgIssueFieldTitle = 'Jira tickets';
+
+    // --- DOM helpers ---
+
+    function removeExistingJiraSection() {
+        const existing = document.getElementById(cfgJiraSectionId);
+        if (existing) existing.remove();
+    }
+
+    // --- Issue field extraction ---
+
+    function getTicketsFromIssueField() {
+        // Look for the "Jira tickets" field button via its aria-label
+        const fieldButton = document.querySelector(`button[aria-label="Edit ${cfgIssueFieldTitle}"]`);
+        if (!fieldButton) {
+            console.log(`[Jira Links] No '${cfgIssueFieldTitle}' issue field found`);
+            return undefined;
+        }
+        // The value is in the second span (the one with the value text class)
+        const valueSpan = fieldButton.querySelector('span[class*="issueFieldValueText"]');
+        if (!valueSpan) {
+            console.log(`[Jira Links] '${cfgIssueFieldTitle}' field has no value span`);
+            return undefined;
+        }
+        const text = valueSpan.textContent.trim();
+        if (!text || text === 'None yet') {
+            console.log(`[Jira Links] '${cfgIssueFieldTitle}' field is empty`);
+            return undefined;
+        }
+        console.log(`[Jira Links] Found '${cfgIssueFieldTitle}' field value: ${text}`);
+        return text;
+    }
+
+
+
+    // --- Ticket parsing ---
+
+    function getTicketIds(ticketsFieldContent) {
+        if (!ticketsFieldContent || ticketsFieldContent.includes("Enter text")) {
+            return [];
+        }
+        return ticketsFieldContent
+            .trim()
+            .split(',')
+            .map(ticket => ticket.trim())
+            .filter(ticket => ticket.length > 0 && /^[A-Z]+-\d+$/.test(ticket));
+    }
+
+    // --- Rendering ---
+
+    function createJiraSection(ticketIDs, jiraBaseURL, targetContainer) {
+        console.log("[Jira Links] Creating links for tickets: ", ticketIDs);
+        removeExistingJiraSection();
+
+        const jiraSection = document.createElement('div');
+        jiraSection.id = cfgJiraSectionId;
+        jiraSection.style.marginTop = '20px';
+
+        jiraSection.innerHTML = `
+          <div style="display: flex; align-items: center; gap: 2px; font-size: 14px;">
+              <span style="font-size: 12px; font-weight: bold;">Jira Tickets:</span>
+              <div style="display: flex; flex-wrap: nowrap; gap: 10px; overflow-x: auto;">
+                  ${ticketIDs
+                    .map(ticketID => `<span style="background-color: #f1f8ff; padding: 5px 10px; border-radius: 5px; white-space: nowrap; font-size: 12px;"><a href="${jiraBaseURL}${ticketID}" target="_blank" style="text-decoration: none; color: #0366d6;">${ticketID}</a></span>`)
+                    .join('')}
+              </div>
+          </div>
+      `;
+
+        if (targetContainer) {
+            targetContainer.appendChild(jiraSection);
+        }
+    }
+
+    function findTargetContainer() {
+        // Issue view: metadata section
+        const issueMetadata = document.querySelector('[data-testid="issue-metadata-fixed"] > div');
+        if (issueMetadata) return issueMetadata;
+
+        // Fallback: issue body
+        const issueBody = document.querySelector('[data-testid="issue-body"]');
+        if (issueBody) return issueBody.parentElement;
+
+        return null;
+    }
+
+    // --- Issue object extraction ---
+
+    function getIssueObject(url) {
+        const urlObj = new URL(url);
+        const pathSegments = urlObj.pathname.split('/');
+
+        let organization, repository, number;
+
+        if (url.includes('/issues/')) {
+            organization = pathSegments[1];
+            repository = pathSegments[2];
+            number = pathSegments[4];
+        } else if (url.includes('/projects/')) {
+            const issueParam = urlObj.searchParams.get('issue');
+            if (issueParam) {
+                const issueParts = issueParam.split('|');
+                organization = issueParts[0];
+                repository = issueParts[1];
+                number = issueParts[2];
+            }
+        }
+
+        return { organization, repository, number };
+    }
+
+    // --- Issue event link ---
+
+    function addLinkToIssueEvent(issue, baseURL) {
+        console.log("[Jira Links] Adding a link to issue events");
+        const phActionsDiv = document.querySelector('div[data-component="PH_Actions"]');
+        if (phActionsDiv !== null) {
+            const innerDiv = phActionsDiv.querySelector('div');
+            if (innerDiv) {
+                // Avoid adding duplicate links
+                if (innerDiv.querySelector('a[title*="issue events"]')) return;
+                const link = document.createElement('a');
+                link.textContent = '🕰️';
+                link.href = baseURL + "/" + issue.organization + "/" + issue.repository + "/txt/" + issue.number + ".txt";
+                link.target = '_blank';
+                link.title = "Display issue events (⚠️ VPN REQUIRED ⚠️)";
+                innerDiv.appendChild(link);
+            }
+        } else {
+            console.log("[Jira Links] Unable to find the issue actions to add the icon to");
+        }
+    }
+
+    // --- Main logic ---
+
+    function collectTicketsFromField(retries = 2) {
+        const content = getTicketsFromIssueField();
+        const ticketIds = getTicketIds(content);
+        if (ticketIds.length > 0) {
+            const container = findTargetContainer();
+            if (!container && retries > 0) {
+                console.log("[Jira Links] Target container not found, retrying...");
+                setTimeout(() => collectTicketsFromField(retries - 1), 1000);
+                return;
+            }
+            createJiraSection(ticketIds, cfgJiraBaseURL, container);
+        }
+    }
+
+    function init() {
+        console.log("[Jira Links] Initializing for URL:", window.location.href);
+        removeExistingJiraSection();
+
+        const issue = getIssueObject(window.location.href);
+        console.log("[Jira Links] Issue:", issue);
+
+        // Add issue event history link (for Jahia org only)
+        if (issue.organization === "Jahia" && issue.number) {
+            addLinkToIssueEvent(issue, cfgIssueEventsBaseURL);
+        }
+
+        // Read Jira tickets directly from the issue field
+        collectTicketsFromField();
+    }
+
+    // --- SPA navigation handling ---
+    // Project views use pushState/replaceState for navigation without full page reloads.
+
+    let lastUrl = window.location.href;
+    let pendingInitTimeout = null;
+
+    function onUrlChange() {
+        const currentUrl = window.location.href;
+        if (currentUrl !== lastUrl) {
+            lastUrl = currentUrl;
+            console.log("[Jira Links] URL changed, re-initializing");
+            // Debounce to avoid duplicate init() calls from rapid mutations
+            clearTimeout(pendingInitTimeout);
+            pendingInitTimeout = setTimeout(init, 1500);
+        }
+    }
+
+    // Intercept pushState and replaceState to detect SPA navigation
+    const originalPushState = history.pushState;
+    history.pushState = function () {
+        originalPushState.apply(this, arguments);
+        try { onUrlChange(); } catch (e) { console.error("[Jira Links]", e); }
+    };
+
+    const originalReplaceState = history.replaceState;
+    history.replaceState = function () {
+        originalReplaceState.apply(this, arguments);
+        try { onUrlChange(); } catch (e) { console.error("[Jira Links]", e); }
+    };
+
+    window.addEventListener('popstate', onUrlChange);
+
+    // Run on initial page load (handle case where load already fired)
+    if (document.readyState === 'complete') {
+        setTimeout(init, 500);
+    } else {
+        window.addEventListener('load', () => {
+            setTimeout(init, 2000);
+        });
+    }
+
+    // Also observe DOM changes for dynamic pane loading (e.g., clicking an issue in project view)
+    const observer = new MutationObserver(() => {
+        onUrlChange();
+    });
+    observer.observe(document.querySelector('head > title') || document.head, {
+        childList: true,
+        subtree: true,
+        characterData: true
+    });
+})();


### PR DESCRIPTION
## Summary

TamperMonkey is closed-source software. This PR switches the recommended userscript manager to [ViolentMonkey](https://violentmonkey.github.io), which is free and open-source.

## Changes

- **New file**: `tools/violentmonkey-support-tickets.js` — a ViolentMonkey-compatible version of the GitHub Issue Jira Links script. Functionally identical, with an updated `@namespace` and `@run-at document-end` metadata header.
- **Updated**: `tools/README.md` — ViolentMonkey is now the recommended extension. The TamperMonkey section is retained as a legacy reference in a collapsed `<details>` block with a deprecation notice.
- **Kept**: `tools/tampermonkey-support-tickets.js` — unchanged, available for reference but no longer recommended.

## Why ViolentMonkey?

ViolentMonkey is actively maintained, open-source (MIT), and available for Chrome, Firefox, and Edge. TamperMonkey has been closed-source since version 4.x.