### PR TITLE
chore: Remove sdk-jahia (archived) from product file sync config

### DIFF
--- a/.github/product-file-sync-config.yml
+++ b/.github/product-file-sync-config.yml
@@ -191,7 +191,6 @@ patterns:
       - Jahia/rolesmanager@main
       - Jahia/saml-authentication-valve@main
       - Jahia/sandbox@main
-      - Jahia/sdk-jahia@main
       - Jahia/search@main
       - Jahia/search-ui-jahia-connector@main
       - Jahia/security-filter-tools@main


### PR DESCRIPTION
### Description
Removed 'Jahia/sdk-jahia@main' from the sync configuration.